### PR TITLE
fixed 00 by converting 37 to 00 on new variable

### DIFF
--- a/roulette.py
+++ b/roulette.py
@@ -152,8 +152,12 @@ while continuePlay == "Y" or continuePlay == "y" and userBalance > 0:
 
     # The below will generate a random number from 0 to 37. Number 37 will be mapped to 00
     rouletteSpinNumber = rouletteSpin()
+    if rouletteSpinNumber == 37:
+        rouletteSpinNumberDisplay = "00"
+    else:
+        rouletteSpinNumberDisplay = rouletteSpinNumber
     rouletteSpinNumberMetadata = [
-        rouletteSpinNumber, oddOrEven(rouletteSpinNumber),
+        rouletteSpinNumberDisplay, oddOrEven(rouletteSpinNumber),
         bottomOrTopHalf(rouletteSpinNumber), DozenSet(rouletteSpinNumber),
         colorbet(rouletteSpinNumber)
     ]


### PR DESCRIPTION
fixed user 00 input 
- changed logic to convert 37 to "00"
- created new variable rouletteSpinNumberDisplay to hold 00 so that other functions expecting an int could continue to user rouletteSpinNumber  without breaking.  
